### PR TITLE
"R" (reload) handles MIDI port updates

### DIFF
--- a/device/device.go
+++ b/device/device.go
@@ -97,11 +97,6 @@ func New(sync, outputName, inputName string) (*Device, error) {
 	// Store port names for later sync configuration
 	d.outputName = outputName
 
-	// Configure sync ports based on initial sync mode
-	if err := d.updateSync(sync, inputName); err != nil {
-		return nil, err
-	}
-
 	return &d, nil
 }
 

--- a/device/playback.go
+++ b/device/playback.go
@@ -38,10 +38,10 @@ func (d *Device) StartPlaybackListeners() {
 	}()
 }
 
-func (d *Device) SetPlaybackConfig(bpm float64, loop bool, sync string) {
+func (d *Device) SetPlaybackConfig(bpm float64, loop bool, sync string, input string) {
 	d.bpm = bpm
 	d.loop = loop
-	d.updateSync(sync)
+	d.updateSync(sync, input)
 }
 
 // SetCurrentPlayable updates the current playable for the device

--- a/device/ports.go
+++ b/device/ports.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"gitlab.com/gomidi/midi/v2"
+	"gitlab.com/gomidi/midi/v2/drivers"
+	"gitlab.com/gomidi/midi/v2/drivers/rtmididrv"
 )
 
 func (d *Device) sendTrack(mm midi.Message) {
@@ -35,66 +37,109 @@ func (d *Device) sendSync(mm midi.Message) {
 	}
 }
 
-// updateSync updates the sync mode and manages MIDI sync listening
-// If sync mode is "follower", it should listen for MIDI sync messages
-// If it's already listening from a previous call, don't do anything
-// Any other sync mode should not listen for sync messages
-// If it is listening from a previous call, it should stop listening
-func (d *Device) updateSync(mode string) {
+// updateSync updates the sync mode and manages MIDI sync port creation and listening
+// This method can be called multiple times to handle sync mode changes
+func (d *Device) updateSync(mode string, inputName string) error {
+
+	modeChanged := d.sync != mode
+	inputChanged := d.inputName != inputName && mode == "follower"
+
+	// If nothing has changed, no need to do anything
+	if !modeChanged && !inputChanged {
+		return nil
+	}
+
+	// Clean up existing sync ports if mode is changing
+	d.cleanupSyncPorts()
+
+	d.inputName = inputName
 	d.sync = mode
 
-	if d.sync != "follower" {
-		// Not in follower mode - stop listening if currently listening
-		if d.listening {
-			d.syncCancelF()
-			if d.syncIn.IsOpen() {
-				err := d.syncIn.Close()
-				if err != nil {
-					d.errorsCh <- err
-				}
-			}
-			d.listening = false
+	// Configure sync ports based on mode
+	switch mode {
+	case "follower":
+		if err := d.configureFollowerSync(); err != nil {
+			return fmt.Errorf("failed to configure follower sync: %w", err)
 		}
-		return
+	case "leader":
+		if err := d.configureLeaderSync(); err != nil {
+			return fmt.Errorf("failed to configure leader sync: %w", err)
+		}
 	}
 
-	// In follower mode - check if already listening
-	if d.listening {
-		// Already listening for sync messages, don't do anything
-		return
+	return nil
+}
+
+// cleanupSyncPorts closes and cleans up existing sync-related MIDI ports
+func (d *Device) cleanupSyncPorts() {
+	// Stop listening if currently listening
+	if d.listening && d.syncCancelF != nil {
+		d.syncCancelF()
+		d.listening = false
 	}
 
-	// Not listening yet - start listening for sync messages
-	if d.syncIn == nil {
-		d.errorsCh <- fmt.Errorf("no MIDI input configured for sync listening")
-		return
-	}
-
-	if !d.syncIn.IsOpen() {
-		err := d.syncIn.Open()
-		if err != nil {
+	// Close sync input if open
+	if d.syncIn != nil && d.syncIn.IsOpen() {
+		if err := d.syncIn.Close(); err != nil {
 			d.errorsCh <- err
 		}
 	}
 
-	// Use the gomidi ListenTo API to handle MIDI input
-	stop, err := midi.ListenTo(d.syncIn, func(msg midi.Message, timestampms int32) {
+	// Close sync output if open
+	if d.syncOut != nil && d.syncOut.IsOpen() {
+		if err := d.syncOut.Close(); err != nil {
+			d.errorsCh <- err
+		}
+	}
 
+	// Reset sync port references
+	d.syncIn = nil
+	d.syncCancelF = nil
+	d.sendSyncF = nil
+}
+
+// configureFollowerSync sets up MIDI input for sync listening
+func (d *Device) configureFollowerSync() error {
+	var syncIn drivers.In
+	var err error
+
+	if d.inputName == "" {
+		// Create virtual input
+		syncIn, err = drivers.Get().(*rtmididrv.Driver).OpenVirtualIn(syncDeviceName)
+		if err != nil {
+			return fmt.Errorf("failed to open virtual MIDI sync input: %w", err)
+		}
+	} else {
+		// Try to connect to existing input
+		syncIn, err = drivers.InByName(d.inputName)
+		if err != nil {
+			return fmt.Errorf("failed to connect to MIDI input '%s': %w", d.inputName, err)
+		}
+	}
+
+	d.syncIn = syncIn
+
+	// Open the input if not already open
+	if !syncIn.IsOpen() {
+		if err := syncIn.Open(); err != nil {
+			return fmt.Errorf("failed to open MIDI sync input: %w", err)
+		}
+	}
+
+	// Start listening for sync messages
+	stop, err := midi.ListenTo(syncIn, func(msg midi.Message, timestampms int32) {
 		switch {
 		case msg.Is(midi.StartMsg):
-
 			// Start message received - trigger clock events
 			if d.state.stopped() {
 				d.PlaySub.Pub()
 			}
 		case msg.Is(midi.StopMsg):
-
 			// Stop message received - stop playback
 			if d.state.playing() {
 				d.StopSub.Pub()
 			}
 		case msg.Is(midi.TimingClockMsg):
-
 			// Timing clock message received - trigger clock events
 			if d.state.playing() {
 				d.ClockSub.Pub()
@@ -108,10 +153,28 @@ func (d *Device) updateSync(mode string) {
 	)
 
 	if err != nil {
-		d.errorsCh <- fmt.Errorf("failed to start MIDI listener: %w", err)
-		return
+		return fmt.Errorf("failed to start MIDI listener: %w", err)
 	}
 
 	d.syncCancelF = stop
 	d.listening = true
+	return nil
+}
+
+// configureLeaderSync sets up MIDI output for sync messages
+func (d *Device) configureLeaderSync() error {
+	// Create dedicated virtual output for sync messages
+	syncOut, err := drivers.Get().(*rtmididrv.Driver).OpenVirtualOut(syncDeviceName)
+	if err != nil {
+		return fmt.Errorf("failed to open virtual MIDI sync output: %w", err)
+	}
+	d.syncOut = syncOut
+
+	sendSyncF, err := midi.SendTo(syncOut)
+	if err != nil {
+		return fmt.Errorf("failed to create MIDI sync sender: %w", err)
+	}
+
+	d.sendSyncF = sendSyncF
+	return nil
 }

--- a/ui/model.go
+++ b/ui/model.go
@@ -83,7 +83,7 @@ func (m *model) setDevicePlaybackConfig() {
 	if m.device != nil {
 		_, playables := m.getCurrentGroup()
 		m.device.SetCurrentPlayable(playables[m.selected.x])
-		m.device.SetPlaybackConfig(m.sequence.BPM, m.sequence.Loop, m.sequence.Sync)
+		m.device.SetPlaybackConfig(m.sequence.BPM, m.sequence.Loop, m.sequence.Sync, m.sequence.Input)
 	}
 }
 


### PR DESCRIPTION
Previously you would need to restart the program if `sync`, `input`, or `output` changed.